### PR TITLE
Revert "maple_dsds: extract: Don't add Sony camera service to camera-…

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -89,10 +89,4 @@ fix_product_path product/etc/permissions/lpa.xml
 fix_product_path product/etc/permissions/qcrilhook.xml
 fix_product_path product/etc/permissions/telephonyservice.xml
 
-#
-# Don't add Sony camera service to camera-daemon tasks
-#
-
-sed -i 's/\/dev\/cpuset\/camera-daemon\/tasks //g' "${DEVICE_ROOT}"/vendor/etc/init/vendor.somc.hardware.camera.provider@1.0-service.rc
-
 "${MY_DIR}"/setup-makefiles.sh


### PR DESCRIPTION
…daemon tasks"

Turns out, this was not the problem with stuck cpu frequencies. We can actually make use of this now.

This reverts commit 768de72951d337577af5efe0589d09bf641dfef8.