### PR TITLE
maple_dsds: Enable split sepolicy for system and vendor

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -33,7 +33,8 @@ PRODUCT_COPY_FILES += \
 
 include $(DEVICE_PATH)/device/*.mk
 
-# Disable treble
+# Disable full treble
 PRODUCT_FULL_TREBLE_OVERRIDE := false
-
+# Enable some treble aspects
 PRODUCT_ENFORCE_VINTF_MANIFEST_OVERRIDE := true
+PRODUCT_SEPOLICY_SPLIT_OVERRIDE := true


### PR DESCRIPTION
Seems like this is a requirement for S now, otherwise we hit some funky neverallows.

While at it, specify in the comments that we are disabling full treble but enable certain aspects of it.